### PR TITLE
Fix graph bug of long premissions to 90 chars #8

### DIFF
--- a/bazaar/templates/front/report/m_permissions.html
+++ b/bazaar/templates/front/report/m_permissions.html
@@ -1,10 +1,10 @@
 {% load get %}
 
 <table class="table table-condensed table-sm">
-  {%  for p in d.detailed_permissions|dictsort:"status" %}
+  {% for p in d.detailed_permissions|dictsort:"status" %}
   <tr>
     <td class="">{% include "front/report/m_severity.html" with s=p.status %}</td>
-    <td class=""><samp>{{ p|get:"_name" }}</samp></td>
+    <td class=""><samp>{{ p|get:"_name"|truncatechars:90 }}</samp></td>
     <td class="">
       {% if p.info %}{{ p.info }}<br>{% endif %}
       <span class="small">{{ p.description }}</span><br>


### PR DESCRIPTION
Fixing the display of long permissions to 90 chars so it doesn't break the layout.

Example: 
![Screenshot from 2021-02-22 13-03-52](https://user-images.githubusercontent.com/3540752/108706523-02640280-750f-11eb-94d1-fb29a84eb29a.png)
