### PR TITLE
Adding a quick search button for domains and IPs

### DIFF
--- a/bazaar/templates/front/report/m_domains.html
+++ b/bazaar/templates/front/report/m_domains.html
@@ -16,12 +16,15 @@
             <i class="nf nf-oct-search"></i>
           </a>
           {% include "front/report/m_copy_to_clipboard.html" with data=domain %}
+          {% include "front/report/m_google_search.html" with data=domain %}
+          </a>
         {% endwith %}
       </td>
       <td class=""><samp>{{ p.geolocation.ip }}</samp>
       </td>
       <td>
         {% include "front/report/m_copy_to_clipboard.html" with data=p.geolocation.ip %}
+        {% include "front/report/m_google_search.html" with data=p.geolocation.ip %}
       </td>
     </tr>
   {% endfor %}

--- a/bazaar/templates/front/report/m_file.html
+++ b/bazaar/templates/front/report/m_file.html
@@ -4,6 +4,7 @@
     <td class=""><samp>{{ d.md5 }}</samp></td>
     <td>
       {% include "front/report/m_copy_to_clipboard.html" with data=d.md5 %}
+      {% include "front/report/m_google_search.html" with data=d.md5 %}
     </td>
   </tr>
   <tr>
@@ -11,6 +12,7 @@
     <td class=""><samp>{{ d.sha1 }}</samp></td>
     <td>
       {% include "front/report/m_copy_to_clipboard.html" with data=d.sha1 %}
+      {% include "front/report/m_google_search.html" with data=d.sha1 %}
     </td>
   </tr>
   <tr>
@@ -18,6 +20,7 @@
     <td class=""><samp>{{ d.apk_hash }}</samp></td>
     <td>
       {% include "front/report/m_copy_to_clipboard.html" with data=d.apk_hash %}
+      {% include "front/report/m_google_search.html" with data=d.apk_hash %}
     </td>
   </tr>
   <tr>

--- a/bazaar/templates/front/report/m_google_search.html
+++ b/bazaar/templates/front/report/m_google_search.html
@@ -1,0 +1,4 @@
+<a class="btn btn-sm btn-link p-0" href='https://google.com/search?q="{{data}}"' data-toggle="tooltip"
+    data-placement="top" target="_blank" title="Search the Internet">
+    <i class="nf nf-fa-google"></i>
+</a>


### PR DESCRIPTION
In this work, we've added a quick search button using Google for domains and IPs in the network section in order to extend the search while doing background investigation on a sample. The searches are put into quotes (") to prevent accidental visit to the domains or precache load by the search engine or the browser. 