### PR TITLE
Adding names of the most popular VT/AV detections

### DIFF
--- a/bazaar/front/forms.py
+++ b/bazaar/front/forms.py
@@ -85,7 +85,7 @@ class SearchForm(forms.Form):
             },
             "sort": {"analysis_date": "desc"},
             "_source": ["apk_hash", "sha256", "uploaded_at", "icon_base64", "handle", "app_name",
-                        "version_code", "size", "dexofuzzy.apk", "quark.threat_level", "vt", "malware_bazaar",
+                        "version_code", "size", "dexofuzzy.apk", "quark.threat_level", "vt", "vt_report", "malware_bazaar",
                         "is_signed", "frosting_data.is_frosted", "features", "andro_cfg.genom"],
             "size": 50,
         }

--- a/bazaar/templates/front/report/m_malware_bazaar.html
+++ b/bazaar/templates/front/report/m_malware_bazaar.html
@@ -120,4 +120,16 @@
       </td>
     </tr>
   </table>
+  <h4>AV Detections</h4>
+  <p class="small text-muted">Threat <i class="fa fa-info-circle small" data-toggle="tooltip" data-placement="top"
+                                      title="Provided by VirusTotal"></i></p>
+  <table class="table table-condensed table-sm">
+    {% for engine,result in d.vt_report.attributes.last_analysis_results.items %}
+      {% if result.result is not None %}
+      <tr class="">
+        <td class="">{{ engine}}</td> <td class="">{{ result.result }}</td>
+      </tr>
+      {% endif %}
+    {% endfor %}
+  </table>
 {% endif %}

--- a/bazaar/templates/front/report/m_malware_bazaar.html
+++ b/bazaar/templates/front/report/m_malware_bazaar.html
@@ -120,16 +120,14 @@
       </td>
     </tr>
   </table>
-  <h4>AV Detections</h4>
+  <h4>Most Popular AV Detections</h4>
   <p class="small text-muted">Threat <i class="fa fa-info-circle small" data-toggle="tooltip" data-placement="top"
                                       title="Provided by VirusTotal"></i></p>
   <table class="table table-condensed table-sm">
-    {% for engine,result in d.vt_report.attributes.last_analysis_results.items %}
-      {% if result.result is not None %}
-      <tr class="">
-        <td class="">{{ engine}}</td> <td class="">{{ result.result }}</td>
-      </tr>
-      {% endif %}
+    {% for i in d.vt_report.attributes.popular_threat_classification.popular_threat_name %}
+    <tr>
+    <td class="">Threat name: {{i.value}}</td> <td class="">Identified {{i.count}} times</td>
+    </tr>
     {% endfor %}
   </table>
 {% endif %}

--- a/bazaar/templates/front/report/m_malware_bazaar.html
+++ b/bazaar/templates/front/report/m_malware_bazaar.html
@@ -126,7 +126,14 @@
   <table class="table table-condensed table-sm">
     {% for i in d.vt_report.attributes.popular_threat_classification.popular_threat_name %}
     <tr>
-    <td class="">Threat name: {{i.value}}</td> <td class="">Identified {{i.count}} times</td>
+      <td class="">Threat name: {{i.value}}
+        <a class="btn btn-sm btn-link p-0 text-decoration-none"
+          href="{% url 'front:home' %}?q=threat_name:*{{ i.value }}*" data-toggle="tooltip"
+          data-placement="top" title="Find similar samples">
+          <i class="nf nf-oct-search"></i>
+        </a>
+      </td> 
+      <td class="">Identified {{i.count}} times</td>
     </tr>
     {% endfor %}
   </table>


### PR DESCRIPTION
In this work, the most common Anti-Virus detection from Virus Total are shown by samples. I didn't wanted to recreate the entire view for every AV engine in order to prevent issue with VT. 

Here is a screenshot of the feature. 

![Screenshot from 2021-07-15 22-14-58](https://user-images.githubusercontent.com/3540752/125851714-998d18be-dbef-4cb3-a0e5-ae45a82fdde4.png)

*Note*: I'd like to fix the bug with searches allowing a pivot from those threat_names to general searches. However, I am still in process of reproducing the bug locally (hence the WIP status).