### PR TITLE
Fixing display issue on VT + adding discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,6 @@ es = Elasticsearch(settings.ELASTICSEARCH_HOSTS)
 mapping = json.load(open('bazaar/es_mappings/apk_analysis.json'))
 es.indices.put_mapping(index=settings.ELASTICSEARCH_APK_INDEX, body=mapping.get('mappings'))
 ```
+# Community
+
+Do you have questions? Do you want to chat with us? Come join us on our discord: [https://discord.gg/aZkRNWQ9](https://discord.gg/aZkRNWQ9)

--- a/bazaar/templates/front/report/m_malware_bazaar.html
+++ b/bazaar/templates/front/report/m_malware_bazaar.html
@@ -120,6 +120,7 @@
       </td>
     </tr>
   </table>
+  {% if d.vt_report.attributes.popular_threat_classification.popular_threat_name %}
   <h4>Most Popular AV Detections</h4>
   <p class="small text-muted">Threat <i class="fa fa-info-circle small" data-toggle="tooltip" data-placement="top"
                                       title="Provided by VirusTotal"></i></p>
@@ -137,4 +138,5 @@
     </tr>
     {% endfor %}
   </table>
+  {% endif %}
 {% endif %}

--- a/bazaar/templates/pages/about.html
+++ b/bazaar/templates/pages/about.html
@@ -31,6 +31,7 @@
             or file an
             issue on <a href="https://github.com/pithus/bazaar">Github</a>.
           </p>
+          <p>You can also come talk to us on our <a href="https://discord.gg/aZkRNWQ9">Discord server</a>.</p>
         </div>
         <div class="col-md-10">
           <h3>We need your support</h3>


### PR DESCRIPTION
This work fixes a display bug on the threat names for the VirusTotal section. It also add the Discord link to the about page and the README. 