### PR TITLE
Fixing the retrieval of main_activity for Androguard #36

### DIFF
--- a/bazaar/core/tasks.py
+++ b/bazaar/core/tasks.py
@@ -72,7 +72,7 @@ def extract_attributes(sha256):
         sign['activities'] = a.get_activities()
         sign['features'] = a.get_features()
         sign['libraries'] = a.get_libraries()
-        sign['main_activity'] = a.get_activities()
+        sign['main_activity'] = a.get_main_activity()
         sign['min_sdk_version'] = a.get_min_sdk_version()
         sign['max_sdk_version'] = a.get_max_sdk_version()
         sign['target_sdk_version'] = a.get_target_sdk_version()

--- a/bazaar/templates/front/report/m_services_et_al.html
+++ b/bazaar/templates/front/report/m_services_et_al.html
@@ -1,3 +1,21 @@
+{% if d.main_activity %}
+<h3>Main Activity</h3>
+<p class="text-muted small">Information computed with <a class="small" target="_blank"
+    href="https://github.com/androguard/androguard">AndroGuard</a>.
+
+<table class="table table-condensed table-sm">
+  <tr>
+    <td>
+      <pre><code>{{ d.main_activity }}</code></pre>
+    </td>
+    <td>
+      {% include "front/report/m_copy_to_clipboard.html" with data=d.main_activity %}
+    </td>
+  </tr>
+</table>
+{% endif %}
+
+
 {% if d.activities %}
 <h3>Activities</h3>
 <p class="text-muted small">Information computed with <a class="small" target="_blank"
@@ -16,7 +34,8 @@
 </table>
 {% endif %}
 
-{% if d.receivers %} <h3>Receivers</h3>
+{% if d.receivers %}
+<h3>Receivers</h3>
 <p class="text-muted small">Information computed with <a class="small" target="_blank"
     href="https://github.com/androguard/androguard">AndroGuard</a>.
 


### PR DESCRIPTION
While working on #36, I noticed that `get_main_activity()` wasn't properly called in the Androguard task. I changed it to retrieve the main activity and added a template to display it above the activities sections. 

However, to see it, the reports must be updated otherwise it will only work for new samples.
![Screenshot from 2021-08-19 09-31-56](https://user-images.githubusercontent.com/3540752/130027427-43e74ac6-08ac-48e0-9459-b95fce4b5a2e.png)
