### PR TITLE
Patch for filtering out unknown tld from the domains and url list #48

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -40,6 +40,7 @@ vt-py
 scipy
 numpy
 pandas
+tld
 
 # Map
 pygal_maps_world


### PR DESCRIPTION
This patch is a temporary solution for the bug of a bad regex in MobSF. It catches domains starting with "www" and in a case of this 7f4dda8c5131fe4f43112f696c1733bb93d3a9f6bef9e1aa4c87891b49874970 sample, it creates a lot of noise for the analyst. 

Hopefully this will be patched upstream, we will look into it. 

