### PR TITLE
Not showing the same sample in similarity tab #50

### DIFF
--- a/bazaar/templates/front/m_similarities.html
+++ b/bazaar/templates/front/m_similarities.html
@@ -7,6 +7,7 @@
   </thead>
   <tbody>
   {% for hash, score in results %}
+    {% if hash != result.sha256 %}
     <tr>
       <td>
         <a href="{% url 'front:report' hash %}">
@@ -22,6 +23,7 @@
         </div>
       </td>
     </tr>
+    {% endif %}
   {% endfor %}
   </tbody>
 </table>


### PR DESCRIPTION
This work won't show the original sample in the similar sample tab (in Threat Intel).