### PR TITLE
Fix: not showing similar samples titles, unless len(r) > 1

### DIFF
--- a/bazaar/templates/front/report.html
+++ b/bazaar/templates/front/report.html
@@ -253,6 +253,7 @@
               {% include "front/report/m_timeline.html" %}
             {% endif %}
             {% if similar_samples %}
+            {% if similar_samples|length > 1 %}
               <div>
                 <h3>Similar samples</h3>
                 <p class="text-muted small">Information computed by <a class="small" target="_blank"
@@ -260,6 +261,7 @@
                 </p>
                 {% include "front/report/m_similar_samples.html" %}
               </div>
+            {% endif %}
             {% endif %}
             {% if result.malware_bazaar or result.vt %}
               <div>


### PR DESCRIPTION
Previously, the "Similar samples" was showing because the number of samples was equal to 1 (the original samples). However, that sample isn't shown. This work fixes that. 