### PR TITLE
Bug/hide current sample in similar searches

### DIFF
--- a/bazaar/core/utils.py
+++ b/bazaar/core/utils.py
@@ -234,7 +234,7 @@ def get_matching_items_by_ssdeep(ssdeep_value, threshold_grade, index, sha256):
             record_ssdeep = f'{chunk_size}:{chunk}:{double_chunk}'
             ssdeep_grade = ssdeep.compare(record_ssdeep, ssdeep_value)
 
-            if ssdeep_grade >= threshold_grade:
+            if ssdeep_grade >= threshold_grade and ssdeep_grade < 100:
                 sha256_list_to_return.append((record['_source']['sha256'], ssdeep_grade))
 
     return sha256_list_to_return


### PR DESCRIPTION
Fix a bug where the current sample is displayed with 100% similarity when doing hash searches on dexofuzzy and ssdeep.

However as I've come to think about it, it might not be the best way to fix it, is it possible for another sample to have a 100% matching dexofuzzy or ssdeep hash while being different ?