### PR TITLE
Fix subtitle for most popular AV detection

### DIFF
--- a/bazaar/templates/front/report/m_malware_bazaar.html
+++ b/bazaar/templates/front/report/m_malware_bazaar.html
@@ -122,8 +122,7 @@
   </table>
   {% if d.vt_report.attributes.popular_threat_classification.popular_threat_name %}
   <h4>Most Popular AV Detections</h4>
-  <p class="small text-muted">Threat <i class="fa fa-info-circle small" data-toggle="tooltip" data-placement="top"
-                                      title="Provided by VirusTotal"></i></p>
+  <p class="text-muted small">Provided by <a class="small" target="_blank" href="https://virustotal.com">VirusTotal</a></p>
   <table class="table table-condensed table-sm">
     {% for i in d.vt_report.attributes.popular_threat_classification.popular_threat_name %}
     <tr>


### PR DESCRIPTION
Changes the subtitle under the AV detection to match better the general subtitle naming scheme

Old:
![Screenshot from 2021-10-11 17-36-56](https://user-images.githubusercontent.com/3540752/136818839-d0354f4f-1c15-4c57-a7cf-a89ca8a726d6.png)

New:
![Screenshot from 2021-10-11 17-45-12](https://user-images.githubusercontent.com/3540752/136818854-79409e53-9e99-4b02-9ce8-c68a43a97f24.png)
