### PR TITLE
fix display duplicate of current sample in dexofuzzy and ssdeep searches

### DIFF
--- a/bazaar/front/forms.py
+++ b/bazaar/front/forms.py
@@ -37,16 +37,16 @@ class SimilaritySearchForm(forms.Form):
     hash = forms.CharField(max_length=128)
     algorithm = forms.ChoiceField(choices=[('ssdeep', 'ssdeep'), ('dexofuzzy', 'dexofuzzy')])
 
-    def do_search(self):
+    def do_search(self, sha=''):
         print(self.cleaned_data)
         results = []
         algorithm = self.cleaned_data['algorithm']
         hash = self.cleaned_data['hash'].strip()
         try:
             if algorithm == 'dexofuzzy':
-                results = get_matching_items_by_dexofuzzy(hash, 25, settings.ELASTICSEARCH_DEXOFUZZY_APK_INDEX, '')
+                results = get_matching_items_by_dexofuzzy(hash, 25, settings.ELASTICSEARCH_DEXOFUZZY_APK_INDEX, sha)
             if algorithm == 'ssdeep':
-                results = get_matching_items_by_ssdeep(hash, 25, settings.ELASTICSEARCH_SSDEEP_APK_INDEX, '')
+                results = get_matching_items_by_ssdeep(hash, 25, settings.ELASTICSEARCH_SSDEEP_APK_INDEX, sha)
 
         except Exception as e:
             print(e)

--- a/bazaar/front/urls.py
+++ b/bazaar/front/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path("apk/", view=basic_upload_view, name="basic_upload"),
     path("apk/<str:sha256>", view=download_sample_view, name="download_sample"),
     path("similar/", view=similarity_search_view, name="similarity_search"),
+    path("similar/<str:sha256>", view=similarity_search_view, name="similarity_search"),
     path("rules/", view=my_rules_view, name="my_rules"),
     path("rules/new", view=my_rule_create_view, name="my_rule_create"),
     path("rules/<str:uuid>/edit", view=my_rule_edit_view, name="my_rule_edit"),

--- a/bazaar/front/view.py
+++ b/bazaar/front/view.py
@@ -116,7 +116,7 @@ class ReportView(View):
                     similar_samples = get_matching_items_by_dexofuzzy(
                         dexofuzzy_hash,
                         25,
-                        settings.ELASTICSEARCH_DEXOFUZZY_APK_INDEX, '')
+                        settings.ELASTICSEARCH_DEXOFUZZY_APK_INDEX, sha)
             except Exception:
                 pass
 
@@ -174,12 +174,12 @@ def basic_upload_view(request):
     return redirect(reverse_lazy('front:home'))
 
 
-def similarity_search_view(request):
+def similarity_search_view(request, sha256=''):
     if request.method == 'GET':
         form = SimilaritySearchForm(request.GET)
         results = None
         if form.is_valid():
-            results = form.do_search()
+            results = form.do_search(sha256)
         return render(request, 'front/similarity_search.html', {'form': form, 'results': results})
 
 

--- a/bazaar/templates/front/report/m_dexofuzzy.html
+++ b/bazaar/templates/front/report/m_dexofuzzy.html
@@ -9,7 +9,7 @@
     </td>
     <td>
       {% include "front/report/m_copy_to_clipboard.html" with data=d.dexofuzzy.apk %}
-      <a class="btn btn-sm btn-link p-0 text-decoration-none" href="{% url 'front:similarity_search' %}?hash={{ d.dexofuzzy.apk }}&algorithm=dexofuzzy"
+      <a class="btn btn-sm btn-link p-0 text-decoration-none" href="{% url 'front:similarity_search' %}{{ d.sha256 }}?hash={{ d.dexofuzzy.apk }}&algorithm=dexofuzzy"
         data-toggle="tooltip" data-placement="top" title="Find similar samples">
         <i class="nf nf-oct-search"></i>
       </a>

--- a/bazaar/templates/front/report/m_ssdeep.html
+++ b/bazaar/templates/front/report/m_ssdeep.html
@@ -11,7 +11,7 @@
     <td>
       <div>
         {% include "front/report/m_copy_to_clipboard.html" with data=d.ssdeep.apk %}
-        <a class="btn btn-sm btn-link p-0 text-decoration-none" href="{% url 'front:similarity_search' %}?hash={{ d.ssdeep.apk }}&algorithm=ssdeep"
+	<a class="btn btn-sm btn-link p-0 text-decoration-none" href="{% url 'front:similarity_search' %}{{ d.sha256 }}?hash={{ d.ssdeep.apk }}&algorithm=ssdeep"
           data-toggle="tooltip" data-placement="top" title="Find similar samples">
           <i class="nf nf-oct-search"></i>
         </a>


### PR DESCRIPTION
Display of similar samples in dexofuzzy and ssdeep searches displayed the current sample with 100% similarity. It is now removed from the search. 
This changes adds the following 'feature' : 

Search with hash as parameter:
`http://127.0.0.1:8001/similar/<sample-sha256>?algorithm=dexofuzzy&hash=<dexo-hash>`

And the default without the hash still works. 