### PR TITLE
Update APKiD from latest commit

### DIFF
--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -21,11 +21,14 @@ COPY ./requirements /requirements
 RUN pip install --upgrade pip
 RUN pip install -r /requirements/local.txt
 
-# Install APKid
-RUN pip install --upgrade wheel
-RUN pip wheel --wheel-dir=/tmp/yara-python --build-option="build" --build-option="--enable-dex" git+https://github.com/VirusTotal/yara-python.git@v3.11.0
-RUN pip install --no-index --find-links=/tmp/yara-python yara-python
-RUN pip install apkid
+# Install APKiD https://github.com/rednaga/APKiD/blob/master/Dockerfile
+RUN git clone https://github.com/rednaga/APKiD.git && \
+    cd APKiD && \
+    git checkout f8720b7a371c31a694d45591af0b023f040febdd && \
+    rm -rf .git && \
+    python prep-release.py && \
+    python setup.py install && \
+    cd ..
 
 COPY ./compose/production/django/entrypoint /entrypoint
 RUN sed -i 's/\r$//g' /entrypoint

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -25,11 +25,14 @@ RUN pip install --upgrade pip
 RUN pip install --no-cache-dir -r /requirements/production.txt \
     && rm -rf /requirements
 
-# Install APKid
-RUN pip install --upgrade wheel
-RUN pip wheel --wheel-dir=/tmp/yara-python --build-option="build" --build-option="--enable-dex" git+https://github.com/VirusTotal/yara-python.git@v3.11.0
-RUN pip install --no-index --find-links=/tmp/yara-python yara-python
-RUN pip install apkid
+# Install APKiD https://github.com/rednaga/APKiD/blob/master/Dockerfile
+RUN git clone https://github.com/rednaga/APKiD.git && \
+    cd APKiD && \
+    git checkout f8720b7a371c31a694d45591af0b023f040febdd && \
+    rm -rf .git && \
+    python prep-release.py && \
+    python setup.py install && \
+    cd ..
 
 COPY ./compose/production/django/entrypoint /entrypoint
 RUN sed -i 's/\r$//g' /entrypoint

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -34,3 +34,7 @@ django-debug-toolbar==3.1.1  # https://github.com/jazzband/django-debug-toolbar
 django-extensions==3.0.9  # https://github.com/django-extensions/django-extensions
 django-coverage-plugin==1.8.0  # https://github.com/nedbat/django_coverage_plugin
 pytest-django==4.1.0  # https://github.com/pytest-dev/pytest-django
+
+# APKiD
+# ------------------------------------------------------------------------------
+yara-python-dex>=1.0.1  # https://github.com/MobSF/yara-python-dex

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -9,3 +9,7 @@ sentry-sdk==0.19.3  # https://github.com/getsentry/sentry-python
 # Django
 # ------------------------------------------------------------------------------
 django-anymail==8.1  # https://github.com/anymail/django-anymail
+
+# APKiD
+# ------------------------------------------------------------------------------
+yara-python-dex>=1.0.1  # https://github.com/MobSF/yara-python-dex


### PR DESCRIPTION
Hi guys,

It seems you were recompiling yara-dex as we used to do in the past. Things got easier now. Also, installing APKiD from PiP wasn't a good idea because we didn't cut many releases in the last years. Therefore, we can tackle a specific commit.

Best