### PR TITLE
Removing mention to Malware Bazar as it isn't used

### DIFF
--- a/bazaar/templates/front/index.html
+++ b/bazaar/templates/front/index.html
@@ -50,8 +50,7 @@
             <div class="control-group mt-1">
               <div class="controls">
                 <button type="submit" class="btn btn-primary" data-toggle="tooltip" data-placement="top"
-                        title="Malicious samples are automatically uploaded to MalwareBazaar.">
-                  <span class="text-warning"><i class="fa fa-exclamation-triangle"></i></span>
+                        title="Upload sample to Pithus">
                   Upload
                 </button>
               </div>

--- a/bazaar/templates/front/index.html
+++ b/bazaar/templates/front/index.html
@@ -49,8 +49,7 @@
             </div>
             <div class="control-group mt-1">
               <div class="controls">
-                <button type="submit" class="btn btn-primary" data-toggle="tooltip" data-placement="top"
-                        title="Upload sample to Pithus">
+                <button type="submit" class="btn btn-primary">
                   Upload
                 </button>
               </div>


### PR DESCRIPTION
This works removes the mention to malware bazar on the upload of the sample as this feature is not used. Not tested yet. 